### PR TITLE
Provide instruction on how to ensure the `gh` command works against the fork

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,8 @@
 
 Before start, please make sure you understand the [potential cost](../README.md#-pricing) and the [limitations](../README.md#-limitations).
 
+> If you need support, feel free to contact [me](mailto:maildog@edmund.dev).
+
 ## 1. Preparation
 
 ### 1.1 Decide on one AWS region
@@ -45,11 +47,18 @@ To begin, please fork the repository and clone it locally.
 ```sh
 # Fork and clone it at the same time
 gh repo fork edmundhung/maildog --clone
+# Or if you would like to create a fork in an organization
+# gh repo fork edmundhung/maildog --clone --org name-of-organization
 ```
 
 ```sh
 # From now on, all commands provided assumes the root of the project being your working directory
 cd maildog
+```
+
+```sh
+# Ensure all `gh` command works against your fork instead of the original repository
+export GH_REPO=[YOUR USER/ORGANIZATION NAME]/maildog;
 ```
 
 ```sh

--- a/examples/maildog.config.json
+++ b/examples/maildog.config.json
@@ -16,13 +16,13 @@
       }
     },
     */
-    "maildog.edmund.dev": {
+    "maildog.dev": {
       "fromEmail": "noreply",
       "scanEnabled": true,
       "tlsEnforced": true,
       "alias": {
-        "tester": {
-          "description": "For testing", // For your reference only
+        "edmund": {
+          "description": "Author", // For your reference only
           "to": ["me@edmund.dev"]
         }
       }


### PR DESCRIPTION
The way the default repo is set for gh commands is a bit confusing and not consistent as of gh version 1.11.0. 

e.g. `gh repo view` does not respect the `GH_REPO` env variables while `gh secret` works with env variables but instead ignores the `gh-resolved` git config set internally by the `gh` cli.

For now, the env approach covers all our needs. But we should review it again if we add new command usage in the future.

> Notes: If you would like to reset the default repo set, check your git config as suggested on https://github.com/cli/cli/issues/1864

fix #8

