### PR TITLE
chore(release): add custom release rule for web & extensions scope

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize, closed, reopened]
     paths:
-      - '.github/wokrflows/validate.yaml'
+      - '.github/workflows/validate.yaml'
       - 'lib/**'
       - 'bin/**'
       - 'examples/maildog.config.json'

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types: [opened, synchronize, closed, reopened]
     paths-ignore:
+      - 'packages/web/**'
+      - 'packages/extensions/**'
       - 'docs/**'
       - README.md
     branches:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,11 +2,15 @@ name: Validate Changes
 on:
   pull_request:
     types: [opened, synchronize, closed, reopened]
-    paths-ignore:
-      - 'packages/web/**'
-      - 'packages/extensions/**'
-      - 'docs/**'
-      - README.md
+    paths:
+      - '.github/wokrflows/validate.yaml'
+      - 'lib/**'
+      - 'bin/**'
+      - 'examples/maildog.config.json'
+      - 'pacakge.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'cdk.json'
     branches:
       - main
 

--- a/release.config.js
+++ b/release.config.js
@@ -3,7 +3,18 @@
 module.exports = {
   branches: ['main'],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'angular', // default
+        releaseRules: [
+          // Explained on https://github.com/semantic-release/commit-analyzer#releaserules
+          // Mark all web & extensions as `patch` until official release
+          { scope: 'web', release: 'patch' },
+          { scope: 'extensions', release: 'patch' },
+        ],
+      },
+    ],
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     [


### PR DESCRIPTION
It was a pain to maintain an extra development branch just for not polluting the release schedule of
the core features. By applying custom release rule, we should be able to release all experimental
components as patch until it is mature enough.